### PR TITLE
fix: Rename import config file name on pg_dump-to-s3.sh

### DIFF
--- a/pg_dump-to-s3.sh
+++ b/pg_dump-to-s3.sh
@@ -16,7 +16,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Import config file
-source $DIR/pg_dump-to-s3.conf
+source $DIR/.conf
 
 # Vars
 NOW=$(date +"%Y-%m-%d-at-%H-%M-%S")


### PR DESCRIPTION
# Description

Thank you for merging my previous pull request (https://github.com/gabfl/pg_dump-to-s3/pull/6). I see that you changed the config file name from `pg_dump-to-s3.conf` to `.conf`. I found that the `pg_dump-to-s3.sh` file also needs to be adjusted. 