### PR TITLE
Add option to store config file in home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Automatically dump and archive PostgreSQL backups to Amazon S3.
 ## Setup
 
  - Use `aws configure` to store your AWS credentials in `~/.aws` ([read documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration))
- - Edit `.conf` and set your PostgreSQL's credentials and the list of databases to back up
+ - Edit `.conf` and set your PostgreSQL's credentials and the list of databases to back up. Optionally, the file can be moved to the home directory in `~/.pg_dump-to-s3.conf`.
  - If your PostgreSQL connection uses a password, you will need to store it in `~/.pgpass` ([read documentation](https://www.postgresql.org/docs/current/static/libpq-pgpass.html))
 
 ## Usage

--- a/pg_dump-to-s3.sh
+++ b/pg_dump-to-s3.sh
@@ -16,7 +16,11 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Import config file
-source $DIR/.conf
+if [ -f "${HOME}/.pg_dump-to-s3.conf" ]; then
+    source ${HOME}/.pg_dump-to-s3.conf
+else
+    source $DIR/.conf
+fi
 
 # Vars
 NOW=$(date +"%Y-%m-%d-at-%H-%M-%S")

--- a/pg_restore-from-s3.sh
+++ b/pg_restore-from-s3.sh
@@ -6,7 +6,11 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Import config file
-source $DIR/.conf
+if [ -f "${HOME}/.pg_dump-to-s3.conf" ]; then
+    source ${HOME}/.pg_dump-to-s3.conf
+else
+    source $DIR/.conf
+fi
 
 # Usage
 __usage="


### PR DESCRIPTION
re https://github.com/gabfl/pg_dump-to-s3/issues/10

The config file can now *optionally* be stored in `~/.pg_dump-to-s3.conf`.