### PR TITLE
refactor(scripts): improve backup and restore scripts robustness

### DIFF
--- a/.conf
+++ b/.conf
@@ -19,5 +19,15 @@ PG_DATABASES="database1,database2,database3"
 # Bucket and path within S3
 S3_PATH="my_bucket/my_directory"
 
-# Number of days until the backups are deleted from S3
-DELETE_AFTER="7 days"
+# Number of days until the backups are deleted from S3 (e.g. 7 or "7 days")
+DELETE_AFTER="7"
+
+# Optional: S3 storage class (STANDARD, STANDARD_IA, GLACIER, etc.)
+STORAGE_CLASS="STANDARD_IA"
+
+# Optional: pg_dump compression level (0-9). 0 disables compression.
+PG_DUMP_COMPRESSION=0
+
+# Optional: S3 server-side encryption. Use AES256 or aws:kms.
+# S3_SSE="AES256"
+# S3_SSE_KMS_KEY_ID="your-kms-key-id"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,31 @@ Automatically dump and archive PostgreSQL backups to Amazon S3.
 
 ## Requirements
 
- - [AWS cli](https://aws.amazon.com/cli): ```pip install awscli```
+- [AWS CLI](https://aws.amazon.com/cli)
+- `python3` (used for cross-platform date handling)
+- `pg_dump`, `pg_restore`, and `psql` available in `PATH`
 
 ## Setup
 
- - Use `aws configure` to store your AWS credentials in `~/.aws` ([read documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration))
- - Edit `.conf` and set your PostgreSQL's credentials and the list of databases to back up. Optionally, the file can be moved to the home directory in `~/.pg_dump-to-s3.conf`.
- - If your PostgreSQL connection uses a password, you will need to store it in `~/.pgpass` ([read documentation](https://www.postgresql.org/docs/current/static/libpq-pgpass.html))
+- Use `aws configure` to store your AWS credentials in `~/.aws` ([docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration))
+- Copy `.conf` to either the project root or `~/.pg_dump-to-s3.conf` and update the values.
+- If your PostgreSQL connection uses a password, store it securely in `~/.pgpass` ([docs](https://www.postgresql.org/docs/current/static/libpq-pgpass.html)).
+
+### Configuration keys (`.conf`)
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `PG_HOST` | PostgreSQL host | _required_ |
+| `PG_USER` | PostgreSQL user | _required_ |
+| `PG_PORT` | PostgreSQL port | _required_ |
+| `PG_DATABASES` | Comma-separated list of databases to back up | _required_ |
+| `S3_PATH` | Bucket and prefix (e.g. `my-bucket/backups`) | _required_ |
+| `DELETE_AFTER` | Retention window in days (e.g. `7` or `7 days`) | _required_ |
+| `STORAGE_CLASS` | S3 storage class for uploads | `STANDARD_IA` |
+| `PG_DUMP_COMPRESSION` | `pg_dump` compression level `0-9` | `0` |
+| `S3_SSE` | Optional S3 server-side encryption (`AES256` or `aws:kms`) | _unset_ |
+| `S3_SSE_KMS_KEY_ID` | KMS key ID when `S3_SSE=aws:kms` | _unset_ |
+| `TMPDIR` | Temp directory for dump files | `/tmp` |
 
 ## Usage
 
@@ -26,6 +44,11 @@ Automatically dump and archive PostgreSQL backups to Amazon S3.
 # ...done!
 ```
 
+Notes:
+- Retention is computed with `python3`, so it works on macOS and Linux.
+- The bucket/prefix must already exist and your AWS credentials need permission to `s3:GetObject`, `PutObject`, `DeleteObject`, and `ListBucket` on that prefix.
+- Server-side encryption and storage class can be overridden via config (see above).
+
 ## Restore a backup
 
 ```bash
@@ -37,3 +60,5 @@ Automatically dump and archive PostgreSQL backups to Amazon S3.
 # Database my_database_1 already exists, skipping creation
 # 2023-06-28-at-22-17-15_my_database_1.dump restored to database my_database_1
 ```
+
+Restores will create the target database if it does not exist. Keep your `.conf` (or `~/.pg_dump-to-s3.conf`) in sync with the Postgres connection details used for backup.

--- a/pg_dump-to-s3.sh
+++ b/pg_dump-to-s3.sh
@@ -1,78 +1,114 @@
 #!/usr/bin/env bash
 
-#                     _                             _                  _____ 
-#  _ __   __ _     __| |_   _ _ __ ___  _ __       | |_ ___        ___|___ / 
-# | '_ \ / _` |   / _` | | | | '_ ` _ \| '_ \ _____| __/ _ \ _____/ __| |_ \ 
+#                     _                             _                  _____
+#  _ __   __ _     __| |_   _ _ __ ___  _ __       | |_ ___        ___|___ /
+# | '_ \ / _` |   / _` | | | | '_ ` _ \| '_ \ _____| __/ _ \ _____/ __| |_ \
 # | |_) | (_| |  | (_| | |_| | | | | | | |_) |_____| || (_) |_____\__ \___) |
-# | .__/ \__, |___\__,_|\__,_|_| |_| |_| .__/       \__\___/      |___/____/ 
-# |_|    |___/_____|                   |_|                                   
+# | .__/ \__, |___\__,_|\__,_|_| |_| |_| .__/       \__\___/      |___/____/
+# |_|    |___/_____|                   |_|
 #
 # Project at https://github.com/gabfl/pg_dump-to-s3
 #
 
-set -e
+set -euo pipefail
 
-# Set current directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONFIG_FILE="${HOME}/.pg_dump-to-s3.conf"
+DEFAULT_CONFIG_FILE="$DIR/.conf"
 
-# Import config file
-if [ -f "${HOME}/.pg_dump-to-s3.conf" ]; then
-    source ${HOME}/.pg_dump-to-s3.conf
+if [ -f "$CONFIG_FILE" ]; then
+    source "$CONFIG_FILE"
+elif [ -f "$DEFAULT_CONFIG_FILE" ]; then
+    source "$DEFAULT_CONFIG_FILE"
 else
-    source $DIR/.conf
+    echo "Configuration file not found. Create $DEFAULT_CONFIG_FILE or $CONFIG_FILE."
+    exit 1
 fi
 
-# Vars
-NOW=$(date +"%Y-%m-%d-at-%H-%M-%S")
-DELETETION_TIMESTAMP=`[ "$(uname)" = Linux ] && date +%s --date="-$DELETE_AFTER"` # Maximum date (will delete all files older than this date)
+fail() {
+    echo "Error: $1" >&2
+    exit 1
+}
 
-# Split databases
-IFS=',' read -ra DBS <<< "$PG_DATABASES"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required for cross-platform date handling."
+command -v aws >/dev/null 2>&1 || fail "aws cli not found in PATH."
+command -v pg_dump >/dev/null 2>&1 || fail "pg_dump not found in PATH."
 
-# Delete old files
-echo " * Backup in progress.,.";
-
-# Loop thru databases
-for db in "${DBS[@]}"; do
-    FILENAME="$NOW"_"$db"
-
-
-    echo "   -> backing up $db..."
-
-    # Dump database
-    pg_dump -Fc -h $PG_HOST -U $PG_USER -p $PG_PORT $db > /tmp/"$FILENAME".dump
-
-    # Copy to S3
-    aws s3 cp /tmp/"$FILENAME".dump s3://$S3_PATH/"$FILENAME".dump --storage-class STANDARD_IA
-
-    # Delete local file
-    rm /tmp/"$FILENAME".dump
-
-    # Log
-    echo "      ...database $db has been backed up"
+REQUIRED_VARS=(PG_HOST PG_USER PG_PORT PG_DATABASES S3_PATH DELETE_AFTER)
+for var in "${REQUIRED_VARS[@]}"; do
+    [ -n "${!var:-}" ] || fail "Config variable $var is required."
 done
 
-# Delere old files
-echo " * Deleting old backups...";
+# Normalize retention in days (takes first numeric token, e.g. '7 days' -> 7)
+RETENTION_DAYS_RAW="${DELETE_AFTER%% *}"
+[[ "$RETENTION_DAYS_RAW" =~ ^[0-9]+$ ]] || fail "DELETE_AFTER must start with a number of days (e.g. '7 days' or '14')."
+RETENTION_DAYS="$RETENTION_DAYS_RAW"
 
-# Loop thru files
-aws s3 ls s3://$S3_PATH/ | while read -r line;  do
-    # Get file creation date
-    createDate=`echo $line|awk {'print $1" "$2'}`
-    createDate=`date -d"$createDate" +%s`
+RETENTION_THRESHOLD_TS=$(python3 - <<PY
+import time
+days = int("$RETENTION_DAYS")
+print(int(time.time() - days * 86400))
+PY
+)
 
-    if [[ $createDate -lt $DELETETION_TIMESTAMP ]]
-    then
-        # Get file name
-        FILENAME=`echo $line|awk {'print $4'}`
-        if [[ $FILENAME != "" ]]
-          then
-            echo "   -> Deleting $FILENAME"
-            aws s3 rm s3://$S3_PATH/$FILENAME
-        fi
+NOW=$(date +"%Y-%m-%d-at-%H-%M-%S")
+TMP_DIR="${TMPDIR:-/tmp}"
+STORAGE_CLASS="${STORAGE_CLASS:-STANDARD_IA}"
+PG_DUMP_COMPRESSION="${PG_DUMP_COMPRESSION:-0}"
+
+[ "$PG_DUMP_COMPRESSION" -ge 0 ] 2>/dev/null || fail "PG_DUMP_COMPRESSION must be an integer between 0-9."
+[ "$PG_DUMP_COMPRESSION" -le 9 ] 2>/dev/null || fail "PG_DUMP_COMPRESSION must be an integer between 0-9."
+
+IFS=',' read -ra DBS <<< "$PG_DATABASES"
+
+echo " * Backup in progress..."
+for db in "${DBS[@]}"; do
+    FILENAME="${NOW}_${db}"
+    BACKUP_FILE="${TMP_DIR}/${FILENAME}.dump"
+
+    echo "   -> backing up ${db}..."
+
+    pg_dump -Fc -Z "$PG_DUMP_COMPRESSION" -h "$PG_HOST" -U "$PG_USER" -p "$PG_PORT" "$db" > "$BACKUP_FILE"
+
+    AWS_CP_ARGS=(--storage-class "$STORAGE_CLASS")
+    [ -n "${S3_SSE:-}" ] && AWS_CP_ARGS+=(--sse "$S3_SSE")
+    [ -n "${S3_SSE_KMS_KEY_ID:-}" ] && AWS_CP_ARGS+=(--sse-kms-key-id "$S3_SSE_KMS_KEY_ID")
+
+    aws s3 cp "$BACKUP_FILE" "s3://${S3_PATH}/${FILENAME}.dump" "${AWS_CP_ARGS[@]}"
+
+    rm -f "$BACKUP_FILE"
+    echo "      ...database ${db} has been backed up"
+done
+
+echo " * Deleting old backups..."
+aws s3 ls "s3://${S3_PATH}/" | while read -r line; do
+    # Skip empty lines
+    [ -z "$line" ] && continue
+    # Extract filename (4th column); if absent, skip (could be directory)
+    FILENAME=$(echo "$line" | awk '{print $4}')
+    [ -z "$FILENAME" ] && continue
+
+    createDate=$(echo "$line" | awk '{print $1" "$2}')
+    FILE_TS=$(python3 - <<PY
+import datetime
+from datetime import timezone
+ts = "$createDate"
+try:
+    dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    print(int(dt.timestamp()))
+except Exception:
+    print("")
+PY
+)
+
+    [ -z "$FILE_TS" ] && { echo "   -> skipping $FILENAME (could not parse date: $createDate)"; continue; }
+
+    if [ "$FILE_TS" -lt "$RETENTION_THRESHOLD_TS" ]; then
+        echo "   -> Deleting $FILENAME"
+        aws s3 rm "s3://${S3_PATH}/${FILENAME}"
     fi
-done;
+done
 
 echo ""
-echo "...done!";
+echo "...done!"
 echo ""

--- a/pg_restore-from-s3.sh
+++ b/pg_restore-from-s3.sh
@@ -1,49 +1,59 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-# Set current directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONFIG_FILE="${HOME}/.pg_dump-to-s3.conf"
+DEFAULT_CONFIG_FILE="$DIR/.conf"
 
-# Import config file
-if [ -f "${HOME}/.pg_dump-to-s3.conf" ]; then
-    source ${HOME}/.pg_dump-to-s3.conf
+if [ -f "$CONFIG_FILE" ]; then
+    source "$CONFIG_FILE"
+elif [ -f "$DEFAULT_CONFIG_FILE" ]; then
+    source "$DEFAULT_CONFIG_FILE"
 else
-    source $DIR/.conf
+    echo "Configuration file not found. Create $DEFAULT_CONFIG_FILE or $CONFIG_FILE."
+    exit 1
 fi
 
-# Usage
 __usage="
 USAGE:
-  $(basename $0) [db target] [s3 object]
+  $(basename "$0") [db target] [s3 object]
 
 EXAMPLE
-  $(basename $0) service 2023-06-28-at-10-29-44_service.dump
+  $(basename "$0") service 2023-06-28-at-10-29-44_service.dump
 "
 
-if [[ -z "$@" ]]; then
+if [ "$#" -lt 2 ]; then
     echo "$__usage"
-    exit 0
+    exit 1
 fi
 
-# Download backup from s3
-aws s3 cp s3://$S3_PATH/$2 /tmp/$2
+command -v aws >/dev/null 2>&1 || { echo "aws cli not found in PATH."; exit 1; }
+command -v pg_restore >/dev/null 2>&1 || { echo "pg_restore not found in PATH."; exit 1; }
+command -v psql >/dev/null 2>&1 || { echo "psql not found in PATH."; exit 1; }
 
-# Create database if not exists
-DB_EXISTS=$(psql -h $PG_HOST -p $PG_PORT -U $PG_USER -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$1'")
-if [ "$DB_EXISTS" = "1" ]
-then
-    echo "Database $1 already exists, skipping creation"
-    # Restore database
-    pg_restore -h $PG_HOST -U $PG_USER -p $PG_PORT -d $1 -Fc --clean /tmp/$2
+REQUIRED_VARS=(PG_HOST PG_USER PG_PORT S3_PATH)
+for var in "${REQUIRED_VARS[@]}"; do
+    [ -n "${!var:-}" ] || { echo "Config variable $var is required."; exit 1; }
+done
+
+TARGET_DB="$1"
+S3_OBJECT="$2"
+TMP_DIR="${TMPDIR:-/tmp}"
+LOCAL_BACKUP="${TMP_DIR}/${S3_OBJECT}"
+
+echo "Downloading s3://${S3_PATH}/${S3_OBJECT}..."
+aws s3 cp "s3://${S3_PATH}/${S3_OBJECT}" "$LOCAL_BACKUP"
+
+DB_EXISTS=$(psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${TARGET_DB}'")
+if [ "$DB_EXISTS" = "1" ]; then
+    echo "Database ${TARGET_DB} already exists, skipping creation"
+    pg_restore -h "$PG_HOST" -U "$PG_USER" -p "$PG_PORT" -d "$TARGET_DB" -Fc --clean "$LOCAL_BACKUP"
 else
-    echo "Creating database $1"
-    createdb -h $PG_HOST -p $PG_PORT -U $PG_USER -T template0 $1
-    # Restore database
-    pg_restore -h $PG_HOST -U $PG_USER -p $PG_PORT -d $1 -Fc /tmp/$2
+    echo "Creating database ${TARGET_DB}"
+    createdb -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -T template0 "$TARGET_DB"
+    pg_restore -h "$PG_HOST" -U "$PG_USER" -p "$PG_PORT" -d "$TARGET_DB" -Fc "$LOCAL_BACKUP"
 fi
 
-# Remove backup file
-rm /tmp/$2
-
-echo "$2 restored to database $1"
+rm -f "$LOCAL_BACKUP"
+echo "${S3_OBJECT} restored to database ${TARGET_DB}"


### PR DESCRIPTION
Updated the scripts and docs to close the gaps:

- Hardened config loading and validation, added cross-platform retention calculation (python3), optional S3 storage class/SSE, pg_dump compression, and safer temp handling in `pg_dump-to-s3.sh`; added checks and clearer usage in `pg_restore-from-s3.sh`.
- Expanded `.conf` with the new optional settings and clarified required fields.
- Rewrote README with full config key descriptions, prerequisites, retention/platform notes, and clarified usage/permissions.

**Notes:**
- New prerequisite: `python3` (already noted in README) plus AWS CLI and PostgreSQL client tools in PATH.
- Configure `DELETE_AFTER` as a number of days (e.g., `7` or `7 days`), `STORAGE_CLASS`, optional S`3_SSE/S3_SSE_KMS_KEY_ID`, and `PG_DUMP_COMPRESSION` as needed.
- Tests: not run (scripts are bash utilities; recommend a quick backup/restore against a test database + bucket to confirm).